### PR TITLE
drupaldecoupled-0: Fixed gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,126 @@
+# Ignore configuration files that may contain sensitive information.
+local.settings.php
+local.drushrc.php
+local.aliases.drushrc.php
+local.services.yml
+tests/behat/local.yml
+box/local.config.yml
+*.local
+project.local.yml
+
+# Ignore drupal core.
+docroot/core
+
+# Ignore paths that contain user-generated content.
+docroot/sites/*/files
+/files-private
+docroot/sites/*/private
+
+# Ignore contrib modules. These should be created during build process.
+docroot/modules/contrib
+docroot/themes/contrib
+docroot/profiles/contrib
+docroot/libraries
+drush/contrib
+
+# Ignore custom theme build artifacts
+docroot/themes/custom/*/node_modules
+docroot/themes/custom/*/css
+docroot/themes/custom/*/styleguide
+
+# Ignore build artifacts
+/deploy
+bin/*
+tmp
+reports
+
+# OS X
 .DS_Store
-.idea
-/.vscode
-decoupled_js/tmp/*
-vendor/*
-docroot/sites/default/files/php/*
-docroot/core/*
-docroot/modules/contrib/*
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Eclipse
+*.pydevproject
+.project
+.metadata
+tmp/**
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.classpath
+.settings/
+.loadpath
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpathk
+
+# Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# User-specific stuff:
+.idea/
+
+#XHProf
+xhprof_*
+
+#Composer vendor
+vendor/
+vendor/.git
+
+#Sass
+.sass-cache
+*.css.map
+
+#Netbeans IDE
+nbproject
+nbproject/*
+
+# DrupalVM
+.vagrant/
+
+# DevDesktop
+*.dd
+
+#Exports
+*.gz
+*.sql
+*.zip
+
+# PHPStorm
+atlassian-ide-plugin.xml


### PR DESCRIPTION
This updates the .gitignore file to what BLT normally provides by default.

Not sure exactly how this got created in the first place, I'm guessing it's an artifact of the decoupling of the JS and Drupal repos.