### PR TITLE
Removed local file.

### DIFF
--- a/blt/project.local.yml
+++ b/blt/project.local.yml
@@ -1,7 +1,0 @@
-environment: local
-drush:
-  default_alias: drupaldecoupled.local
-  aliases:
-    local: drupaldecoupled.local
-vm:
-  enable: true

--- a/blt/project.yml
+++ b/blt/project.yml
@@ -38,8 +38,6 @@ target-hooks:
     command: 'echo ''No post-deploy build configured.'''
 behat:
   web-driver: selenium
-vm:
-  enable: true
 disable-targets:
     git:
       commit-msg: true


### PR DESCRIPTION
I'm not sure how this file got committed to the repo, but it shouldn't be there. It's what was causing errors about the missing VM on Pipelines deploys.

The way this is supposed to work is that when individual developers clone the repo and run `blt vm`, then `project.local.yml` gets configured _only on their local machine_ to use the VM.